### PR TITLE
feat: Explicitly use mysql `NULL` for  javascript `null` values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icesql",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "icesql",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "lodash.zip": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icesql",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "query SQL databases with strict typing in Node.js",
   "keywords": [
     "mysql",

--- a/src/template/tag.ts
+++ b/src/template/tag.ts
@@ -8,6 +8,10 @@ const argumentToParameters = (arg: any): string => {
     return '';
   }
 
+  if (arg === null) {
+    return 'NULL';
+  }
+
   if (Array.isArray(arg)) {
     return `${createListOfSqlParams(arg.length)}`;
   }
@@ -21,7 +25,11 @@ export class SQLStatement implements QueryObject {
 
   constructor(strings: string[], args: QueryArg[]) {
     this.arguments = (args ?? [])
-      .reduce((acc: QueryArg[], arg) => [...acc, ...(arg instanceof SQLStatement ? arg.values : [arg])], []) // extract and include args from QueryObjects
+      // extract and include args from QueryObjects
+      .reduce(
+        (acc: QueryArg[], arg) => [...acc, ...(arg instanceof SQLStatement ? arg.values : arg === null ? [] : [arg])],
+        []
+      )
       .flat();
 
     if (this.arguments.some(arg => arg === undefined)) {

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -1,0 +1,2 @@
+export const filterAndMap = <T, S>(array: T[], filter: (e: T) => boolean, mapper: (e: T) => S) =>
+  array.reduce((acc, current) => (filter(current) ? [...acc, mapper(current)] : acc), [] as S[]);

--- a/test/unit/template/index.test.ts
+++ b/test/unit/template/index.test.ts
@@ -61,12 +61,12 @@ describe('update', () => {
     });
   });
 
-  it(`should return DELETE statement with WHERE condition`, () => {
-    const now = new Date();
-    const statement = remove<TestType>({ name: 'name', created_at: { $gt: now } }, 'user');
+  it(`should return UPDATE statement that can set value to 'NULL'`, () => {
+    const statement = update<TestType>({ id: 123 }, 'user', { name: null });
+    expect(statement.sql).toBe('UPDATE user SET name = NULL WHERE id = ?');
     expect(statement).toEqual({
-      sql: `DELETE FROM user WHERE name = ? AND created_at > ?`,
-      values: ['name', now],
+      sql: `UPDATE user SET name = NULL WHERE id = ?`,
+      values: [123],
     });
   });
 });

--- a/test/unit/template/tag.test.ts
+++ b/test/unit/template/tag.test.ts
@@ -26,6 +26,13 @@ describe('sql template', () => {
     });
   });
 
+  it(`should properly handle null input`, () => {
+    expect({ ...SQL`UPDATE table SET name = ${null} WHERE id IN (${[1, 2, 3, 4]}) AND name = ${'hello'}` }).toEqual({
+      statement: `UPDATE table SET name = NULL WHERE id IN (?,?,?,?) AND name = ?`,
+      arguments: [1, 2, 3, 4, 'hello'],
+    });
+  });
+
   it(`should properly handle date input`, () => {
     const date = new Date(0);
     expect({ ...SQL`SELECT * FROM table WHERE created_at = ${date}` }).toEqual({
@@ -52,8 +59,8 @@ describe('sql template', () => {
 
   it(`should handle nulls in args`, () => {
     expect({ ...SQL`INSERT INTO table SET value = ${null}` }).toEqual({
-      statement: `INSERT INTO table SET value = ?`,
-      arguments: [null],
+      statement: `INSERT INTO table SET value = NULL`,
+      arguments: [],
     });
   });
 

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,4 +1,5 @@
 import { formatSQL, createListOfSqlParams } from '@src/util/format';
+import { filterAndMap } from '@src/util/object';
 
 const queryString = 'SELECT * FROM a';
 
@@ -27,5 +28,21 @@ describe('createListOfSqlParams', () => {
 
   it(`should return a number of '?' characters`, () => {
     expect(createListOfSqlParams(5)).toBe('?,?,?,?,?');
+  });
+});
+
+describe('filterAndMap', () => {
+  it('should filter and map array in one iteration', () => {
+    const entries = [
+      { key: 'a', value: 'b' },
+      { key: 'c', value: 'h' },
+    ];
+
+    const result = filterAndMap(
+      entries,
+      ({ key }) => key !== 'a',
+      ({ value }) => value
+    );
+    expect(result).toEqual(['h']);
   });
 });


### PR DESCRIPTION
Required to set values to `NULL` in `update`/`SQL`, otherwise throws an error if args includes `[null]`.